### PR TITLE
set timeout to render the popup content

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -38,7 +38,9 @@ chrome.tabs.getSelected(null, function(tab) {
     popup += "# Example:  wget -x <b>--load-cookies cookies.txt</b> " + escapeForPre(tab.url) + "\n"; 
     popup += "#\n";
 
-    document.write("<pre>\n"+ popup + content + "</pre>");
+    setTimeout(function(){
+      document.write("<pre>\n"+ popup + content + "</pre>");
+    }, 100)
   });      
 })
 


### PR DESCRIPTION
At some website, the popup is too small and does not resize to fit the content. Please have a look at the snapshot.

<img width="62" alt="cookies txt" src="https://cloud.githubusercontent.com/assets/633976/25603380/cf842b86-2f2d-11e7-90ce-460ae414e092.png">

Chrome Version: 57.0.2987.133 (64-bit)

I didn't figure out the root cause, but I am assuming that the popup fails to resize itself to fit the content. So I move the `document.write(...)` statement in a timeout to allow the popup to re-render after it has been initialized.
